### PR TITLE
Major Refactor to focus more on distinct Player objects.

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -10,42 +10,41 @@ import (
 	"github.com/iotku/mumzic/config"
 	"github.com/iotku/mumzic/helper"
 	"github.com/iotku/mumzic/playback"
-	"github.com/iotku/mumzic/playlist"
 	"github.com/iotku/mumzic/search"
 	"layeh.com/gumble/gumble"
 )
 
 func playOnly(client *gumble.Client) {
 	// Skip Current track for frequent cases where you've just queued a new track and want to start
-	if !playback.IsPlaying() && playlist.Size() == playlist.Position+2 {
-		playback.Play(playlist.Next(), client)
-		playback.DoNext = "next"
-	} else if playlist.Size() > 0 && !playback.IsPlaying() {
+	if !playback.ChannelPlayer().IsPlaying() && playback.ChannelPlayer().Playlist.Size() == playback.ChannelPlayer().Playlist.Position+2 {
+		playback.ChannelPlayer().Play(playback.ChannelPlayer().Playlist.Next())
+		playback.ChannelPlayer().DoNext = "next"
+	} else if playback.ChannelPlayer().Playlist.Size() > 0 && !playback.ChannelPlayer().IsPlaying() {
 		// if Stream and Songlist exists
-		playback.Play(playlist.GetCurrentPath(), client)
-		playback.DoNext = "next"
-	} else if playback.Stream == nil {
+		playback.ChannelPlayer().Play(playback.ChannelPlayer().Playlist.GetCurrentPath())
+		playback.ChannelPlayer().DoNext = "next"
+	} else if playback.ChannelPlayer().Stream == nil {
 		// Do nothing if nothing is queued
 	}
 }
 
 func PlaybackControls(client *gumble.Client, message string, isPrivate bool, sender string) bool {
-	helper.DebugPrintln("IsPlaying:", playback.IsPlaying(), "DoNext:", playback.DoNext)
+	helper.DebugPrintln("IsPlaying:", playback.ChannelPlayer().IsPlaying(), "DoNext:", playback.ChannelPlayer().DoNext)
 
 	if isCommand(message, "play ") {
 		id := helper.LazyRemovePrefix(message, "play ")
-		if id != "" && playlist.Size() == 0 {
+		if id != "" && playback.ChannelPlayer().Playlist.Size() == 0 {
 			// Add to queue then start playing queue
-			queued := playlist.AddToQueue(isPrivate, sender, id, client)
+			queued := playback.ChannelPlayer().Playlist.AddToQueue(isPrivate, sender, id)
 			if queued == true {
-				playback.Play(playlist.GetCurrentPath(), client)
-				playback.DoNext = "next"
+				playback.ChannelPlayer().Play(playback.ChannelPlayer().Playlist.GetCurrentPath())
+				playback.ChannelPlayer().DoNext = "next"
 			}
 		} else if id == "" {
 			playOnly(client)
 		} else {
-			playlist.AddToQueue(isPrivate, sender, id, client)
-			playback.DoNext = "next"
+			playback.ChannelPlayer().Playlist.AddToQueue(isPrivate, sender, id)
+			playback.ChannelPlayer().DoNext = "next"
 			playOnly(client)
 		}
 		return true
@@ -57,31 +56,59 @@ func PlaybackControls(client *gumble.Client, message string, isPrivate bool, sen
 	}
 
 	if isCommand(message, "list") {
-		current := playlist.Position
-		amount := playlist.Size() - current
+		current := playback.ChannelPlayer().Playlist.Position
+		amount := playback.ChannelPlayer().Playlist.Size() - current
 
 		// TODO: Send to more buffer
 		if amount > config.MaxLines {
 			amount = config.MaxLines
 		}
 
-		for i, line := range playlist.GetList(amount) {
+		for i, line := range playback.ChannelPlayer().Playlist.GetList(amount) {
 			helper.MsgDispatch(isPrivate, sender, client, fmt.Sprintf("# %d: %s\n", i, line))
 		}
 
-		helper.MsgDispatch(isPrivate, sender, client, fmt.Sprintf("%d Track(s) Queued.\n", playlist.Size()-current))
+		helper.MsgDispatch(isPrivate, sender, client, fmt.Sprintf("%d Track(s) Queued.\n", playback.ChannelPlayer().Playlist.Size()-current))
 		return true
 	}
 
+	if isCommand(message, "target") {
+		if client.VoiceTarget == nil {
+			println("target nil")
+		} else {
+			println(client.VoiceTarget.ID)
+		}
+		//client.VoiceTarget = &gumble.VoiceTarget{ID: 2}
+		//userTarget := client.Users.Find(sender)
+		//packet := MumbleProto.VoiceTarget{
+		//	Id:      &client.VoiceTarget.ID,
+		//	Targets: make([]*MumbleProto.VoiceTarget_Target, 0, 1),
+		//}
+		//packet.Targets = append(packet.Targets, &MumbleProto.VoiceTarget_Target{
+		//	Session: []uint32{userTarget.Session},
+		//})
+		//
+		//println(client.Conn.WriteProto(&packet))
+		player := playback.NewPlayer(nil, sender)
+		player.PlayFile(playback.ChannelPlayer().Playlist.GetCurrentPath())
+	}
+
+	if isCommand(message, "untarget") {
+		if client.VoiceTarget != nil {
+			client.VoiceTarget.Clear()
+			client.VoiceTarget = nil
+		}
+	}
+
 	// If Stream object doesn't exist yet, don't do anything to avoid dereference
-	if playback.Stream == nil {
+	if playback.ChannelPlayer().Stream == nil {
 		return false
 	}
 
 	// Stop Playback
 	if isCommand(message, "stop") {
-		playback.DoNext = "stop"
-		err := playback.Stream.Stop()
+		playback.ChannelPlayer().DoNext = "stop"
+		err := playback.ChannelPlayer().Stream.Stop()
 		if err != nil {
 			fmt.Println(err.Error())
 		}
@@ -97,14 +124,14 @@ func PlaybackControls(client *gumble.Client, message string, isPrivate bool, sen
 		if err == nil {
 			fmt.Println("Current Volume: ", value)
 			config.VolumeLevel = float32(value)
-			playback.Stream.Volume = float32(value)
+			playback.ChannelPlayer().Stream.Volume = float32(value)
 		}
 		return true
 	}
 
 	// Send current volume to channel
 	if isCommand(message, "vol") {
-		helper.MsgDispatch(isPrivate, sender, client, "Current Volume: "+fmt.Sprintf("%f", playback.Stream.Volume))
+		helper.MsgDispatch(isPrivate, sender, client, "Current Volume: "+fmt.Sprintf("%f", playback.ChannelPlayer().Stream.Volume))
 		return true
 	}
 
@@ -115,12 +142,12 @@ func PlaybackControls(client *gumble.Client, message string, isPrivate bool, sen
 		if err != nil {
 			// If this isn't a proper value Atoi returns and error, probably harmless but maybe not smart.
 			//log.Println(err)
-			playback.SkipBy = 1
+			playback.ChannelPlayer().SkipBy = 1
 		} else {
-			playback.SkipBy = value
+			playback.ChannelPlayer().SkipBy = value
 		}
-		playback.DoNext = "skip"
-		err = playback.Stream.Stop()
+		playback.ChannelPlayer().DoNext = "skip"
+		err = playback.ChannelPlayer().Stream.Stop()
 		helper.DebugPrintln(err)
 		return true
 	}
@@ -145,18 +172,18 @@ func SearchCommands(client *gumble.Client, message string, isPrivate bool, sende
 		if value > config.MaxLines {
 			value = config.MaxLines
 		}
-        plistOrigSize := playlist.Size()
-        hadNext := playlist.HasNext()
+		plistOrigSize := playback.ChannelPlayer().Playlist.Size()
+		hadNext := playback.ChannelPlayer().Playlist.HasNext()
 		for i := 0; i < value; i++ {
 			id := randsrc.Intn(search.MaxDBID)
-			playlist.AddToQueue(isPrivate, sender, strconv.Itoa(id), client)
+			playback.ChannelPlayer().Playlist.AddToQueue(isPrivate, sender, strconv.Itoa(id))
 		}
-        if !playback.IsPlaying() && plistOrigSize == 0 {
-             playback.Play(playlist.GetCurrentPath(), client)           
-        } else if !playback.IsPlaying() && !hadNext {
-            playlist.Skip(1)
-            playback.Play(playlist.GetCurrentPath(), client)
-        }
+		if !playback.ChannelPlayer().IsPlaying() && plistOrigSize == 0 {
+			playback.ChannelPlayer().Play(playback.ChannelPlayer().Playlist.GetCurrentPath())
+		} else if !playback.ChannelPlayer().IsPlaying() && !hadNext {
+			playback.ChannelPlayer().Playlist.Skip(1)
+			playback.ChannelPlayer().Play(playback.ChannelPlayer().Playlist.GetCurrentPath())
+		}
 
 		return true
 	}
@@ -174,7 +201,7 @@ func SearchCommands(client *gumble.Client, message string, isPrivate bool, sende
 
 	if isCommand(message, "saveconf") {
 		config.SaveConfig()
-        return true
+		return true
 	}
 
 	return false

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.10
+	layeh.com/gopus v0.0.0-20161224163843-0ebf989153aa // indirect
 	layeh.com/gumble v0.0.0-20200818122324-146f9205029b
 )
 

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -11,62 +11,62 @@ import (
 )
 
 type msgBundle struct {
-    client *gumble.Client
-    username string // If username not "", consider as private message
-    msg string
+	client   *gumble.Client
+	username string // If username not "", consider as private message
+	msg      string
 }
 
 // Message rate limiting
 var msgBurstCount uint
 var msgLastSentTime time.Time
-var msgChan chan(msgBundle)
+var msgChan chan (msgBundle)
 
 // Useful information
 var BotUsername string
 var ServerHostname string
-
+var MainClient *gumble.Client
 
 func init() {
 	msgBurstCount = 0
 	msgLastSentTime = time.Now()
-    msgChan = make(chan msgBundle)
-    go watchMsgChan()
+	msgChan = make(chan msgBundle)
+	go watchMsgChan()
 }
 
 func watchMsgChan() {
-    for {
-        bundle := <- msgChan	
-        // Mumble servers generally have rate limiting which should be accounted for
-        // Messages sent too fast will be dropped!
-        // Murmur default: Burst = 5, MessageLimit (after burst) 1/sec
+	for {
+		bundle := <-msgChan
+		// Mumble servers generally have rate limiting which should be accounted for
+		// Messages sent too fast will be dropped!
+		// Murmur default: Burst = 5, MessageLimit (after burst) 1/sec
 
-        currentTime := time.Now()
-        
-        // Buffering logic to avoid messages being dropped by sending too fast
-        // TODO: Should the cooldown for private messages be the same as for main channel messages?
-        if msgLastSentTime.Add(5 * time.Second).Before(currentTime) {
-            msgBurstCount = 1
-        } else {
-            msgBurstCount++
-        }
+		currentTime := time.Now()
 
-        if msgBurstCount >= 5 {
-            time.Sleep(1 * time.Second)
-        }
- 
-        // Actually send message to mumble server
-        if (bundle.username == "") {
-            bundle.client.Self.Channel.Send(bundle.msg, false)
-        } else {
-            gumbleUser := bundle.client.Users.Find(bundle.username)
-            if gumbleUser == nil { // User not found.
-                return
-            } 
-            gumbleUser.Send(bundle.msg)
-        }
- 
-        msgLastSentTime = currentTime
-    }
+		// Buffering logic to avoid messages being dropped by sending too fast
+		// TODO: Should the cooldown for private messages be the same as for main channel messages?
+		if msgLastSentTime.Add(5 * time.Second).Before(currentTime) {
+			msgBurstCount = 1
+		} else {
+			msgBurstCount++
+		}
+
+		if msgBurstCount >= 5 {
+			time.Sleep(1 * time.Second)
+		}
+
+		// Actually send message to mumble server
+		if bundle.username == "" {
+			bundle.client.Self.Channel.Send(bundle.msg, false)
+		} else {
+			gumbleUser := bundle.client.Users.Find(bundle.username)
+			if gumbleUser == nil { // User not found.
+				return
+			}
+			gumbleUser.Send(bundle.msg)
+		}
+
+		msgLastSentTime = currentTime
+	}
 }
 
 // StripHTMLTags removes all html tags from string in order to be parsed easier
@@ -77,12 +77,12 @@ func StripHTMLTags(str string) string {
 
 // ChanMsg sends supplied to the current mumble channel the bot is occupying
 func ChanMsg(client *gumble.Client, msg string) {
-    msgChan <- msgBundle{client, "", msg}
+	msgChan <- msgBundle{client, "", msg}
 }
 
 // UserMsg sends msg directly to user by username supplied
 func UserMsg(client *gumble.Client, username string, msg string) {
-    msgChan <- msgBundle{client, username, msg}
+	msgChan <- msgBundle{client, username, msg}
 }
 
 // MsgDispatch will send to either UserMsg or ChanMsg depending on if message is private or not.

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -24,7 +24,6 @@ var msgChan chan (msgBundle)
 // Useful information
 var BotUsername string
 var ServerHostname string
-var MainClient *gumble.Client
 
 func init() {
 	msgBurstCount = 0
@@ -87,7 +86,7 @@ func UserMsg(client *gumble.Client, username string, msg string) {
 
 // MsgDispatch will send to either UserMsg or ChanMsg depending on if message is private or not.
 // For messages that will reply in PM (such as !list) if sent directly to bot
-func MsgDispatch(isPrivate bool, username string, client *gumble.Client, msg string) {
+func MsgDispatch(client *gumble.Client, isPrivate bool, username string, msg string) {
 	if isPrivate {
 		UserMsg(client, username, msg)
 	} else {

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Usage of %s: [flags]\n", os.Args[0])
 		flag.PrintDefaults()
 	}
+
+	var channelPlayer *playback.Player
 	// Start main gumble loop
 	gumbleutil.Main(gumbleutil.AutoBitrate, gumbleutil.Listener{
 		Connect: func(e *gumble.ConnectEvent) {
@@ -35,9 +37,7 @@ func main() {
 			} else {
 				fmt.Println("Not Joining", config.LastChannel)
 			}
-			helper.MainClient = e.Client
-			playback.Players = make([]*playback.Player, 31)
-			playback.Players[0] = playback.NewPlayer(e.Client, "")
+			channelPlayer = playback.NewPlayer(e.Client)
 		},
 		TextMessage: func(e *gumble.TextMessageEvent) {
 			if e.Sender == nil {
@@ -45,12 +45,12 @@ func main() {
 				return
 			}
 
-			isPrivate := (len(e.TextMessage.Channels) == 0) // If no channels, is private message
+			isPrivate := len(e.TextMessage.Channels) == 0 // If no channels, is private message
 			logMessage(e, isPrivate)
 
 			if msgHasCommandPrefix(e) {
-				go commands.PlaybackControls(e.Client, e.Message, isPrivate, e.Sender.Name)
-				go commands.SearchCommands(e.Client, e.Message, isPrivate, e.Sender.Name)
+				go commands.PlaybackControls(channelPlayer, e.Message, isPrivate, e.Sender.Name)
+				go commands.SearchCommands(channelPlayer, e.Message, isPrivate, e.Sender.Name)
 			}
 		},
 		ChannelChange: func(e *gumble.ChannelChangeEvent) {

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/iotku/mumzic/playback"
 	"log"
 	"os"
 	"strings"
@@ -34,7 +35,9 @@ func main() {
 			} else {
 				fmt.Println("Not Joining", config.LastChannel)
 			}
-
+			helper.MainClient = e.Client
+			playback.Players = make([]*playback.Player, 31)
+			playback.Players[0] = playback.NewPlayer(e.Client, "")
 		},
 		TextMessage: func(e *gumble.TextMessageEvent) {
 			if e.Sender == nil {

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -7,68 +7,66 @@ import (
 	"github.com/iotku/mumzic/helper"
 	"github.com/iotku/mumzic/search"
 	"github.com/iotku/mumzic/youtubedl"
-	"layeh.com/gumble/gumble"
 )
 
-// Raw path // Human path
-var Playlist [][]string
-
-// Position In Playlist
-var Position = 0
-
-func pAdd(path, human string) {
-	Playlist = append(Playlist, []string{path, human})
+type List struct {
+	Playlist [][]string
+	Position int
 }
 
-func GetCurrentPath() string {
-	return Playlist[Position][0]
+func (list *List) pAdd(path, human string) {
+	list.Playlist = append(list.Playlist, []string{path, human})
 }
 
-func GetCurrentHuman() string {
-	return Playlist[Position][1]
+func (list *List) GetCurrentPath() string {
+	return list.Playlist[list.Position][0]
 }
 
-func GetList(max int) []string {
+func (list *List) GetCurrentHuman() string {
+	return list.Playlist[list.Position][1]
+}
+
+func (list *List) GetList(max int) []string {
 	var trackList []string
-	for i := Position; i < Position+max; i++ {
-		if Position+max > Size() {
+	for i := list.Position; i < list.Position+max; i++ {
+		if list.Position+max > list.Size() {
 			return trackList
 		}
-		trackList = append(trackList, Playlist[i][1])
+		trackList = append(trackList, list.Playlist[i][1])
 	}
 
 	return trackList
 }
 
-func HasNext() bool {
-	return len(Playlist) > Position+1
+func (list *List) HasNext() bool {
+	return len(list.Playlist) > list.Position+1
 }
 
-func Next() string {
-	if !HasNext() {
+func (list *List) Next() string {
+	if !list.HasNext() {
 		return ""
 	}
-	Position++
-	return GetCurrentPath()
+	list.Position++
+	return list.GetCurrentPath()
 }
 
-func Skip(amount int) string {
-	if Size()+amount < 0 || !HasNext() {
+func (list *List) Skip(amount int) string {
+	if list.Size()+amount < 0 || !list.HasNext() {
 		return ""
 	}
 
-	if Position+amount >= Size() {
+	if list.Position+amount >= list.Size() {
 		amount = 1 // only skip one track
 	}
-	Position = Position + amount
-	return GetCurrentPath()
+	list.Position = list.Position + amount
+	return list.GetCurrentPath()
 }
 
-func Size() int {
-	return len(Playlist)
+func (list *List) Size() int {
+	return len(list.Playlist)
 }
 
-func QueueID(trackID int) (human string) {
+func (list *List) QueueID(trackID int) (human string) {
 	if trackID > search.MaxDBID || trackID < 1 {
 		return ""
 	}
@@ -76,18 +74,18 @@ func QueueID(trackID int) (human string) {
 	if path == "" {
 		return ""
 	}
-	pAdd(path, human)
+	list.pAdd(path, human)
 
 	return human
 }
 
-func QueueYT(url, human string) string {
+func (list *List) QueueYT(url, human string) string {
 	// TODO Check with API if video is valid for youtube links
-	pAdd(url, human)
+	list.pAdd(url, human)
 	return human
 }
 
-func AddToQueue(isPrivate bool, sender string, path string, client *gumble.Client) bool {
+func (list *List) AddToQueue(isPrivate bool, sender string, path string) bool {
 	// For YTDL URLS
 	path = helper.StripHTMLTags(path)
 	if strings.HasPrefix(path, "http") && youtubedl.IsWhiteListedURL(path) == true {
@@ -101,22 +99,22 @@ func AddToQueue(isPrivate bool, sender string, path string, client *gumble.Clien
 		} else {
 			human = path
 		}
-		QueueYT(path, human)
-		helper.MsgDispatch(isPrivate, sender, client, "Added: "+human)
+		list.QueueYT(path, human)
+		helper.MsgDispatch(isPrivate, sender, helper.MainClient, "Added: "+human)
 		return true
 	} else if strings.HasPrefix(path, "http") == true {
-		helper.MsgDispatch(isPrivate, sender, client, "URL Doesn't meet whitelist, sorry.")
+		helper.MsgDispatch(isPrivate, sender, helper.MainClient, "URL Doesn't meet whitelist, sorry.")
 		return false
 	}
 
 	// FOR IDs
 	idn, _ := strconv.Atoi(path)
-	human := QueueID(idn)
+	human := list.QueueID(idn)
 	if human != "" {
-		helper.MsgDispatch(isPrivate, sender, client, "Added: "+human)
+		helper.MsgDispatch(isPrivate, sender, helper.MainClient, "Added: "+human)
 		return true
 	}
 
-	helper.MsgDispatch(isPrivate, sender, client, "Nothing added. (Invalid ID?)")
+	helper.MsgDispatch(isPrivate, sender, helper.MainClient, "Nothing added. (Invalid ID?)")
 	return false
 }


### PR DESCRIPTION
While still somewhat monolithic, these changes leave a lot of extra room for potentially running multiple clients as well as potential for targeting users via whispers.

While I was hoping that I could send multiple VoiceTarget whispers simultaneously I think that's not possible with the mumble protocol without separate distinct connections. That said however, it may be possible to spawn new instances to target specific users. 