### PR TITLE
Initial Album Art Implementation for Local Files

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -16,12 +16,12 @@ func CommandDispatch(player *playback.Player, message string, isPrivate bool, se
 	command, arg := getCommandAndArg(message, isPrivate)
 
 	switch command {
-	case "play":
+	case "play", "add":
 		play(arg, sender, isPrivate, player)
 	case "stop":
 		player.DoNext = "stop"
 		player.Stop()
-	case "skip":
+	case "skip", "next":
 		value, err := strconv.Atoi(arg)
 		if err != nil {
 			player.Skip(1)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"github.com/iotku/mumzic/messages"
 	"strconv"
 	"strings"
 
@@ -32,6 +33,8 @@ func CommandDispatch(player *playback.Player, message string, isPrivate bool, se
 		vol(player, sender, isPrivate, arg)
 	case "list":
 		list(player, sender, isPrivate)
+    case "retarget":
+        player.TargetUsers()
 	case "target":
 		player.AddTarget(sender)
 	case "untarget":
@@ -112,20 +115,20 @@ func list(player *playback.Player, sender string, isPrivate bool) {
 		amount = config.MaxLines
 	}
 
-	output := makeTable("Playlist", "#", "Track Name")
+	output := messages.MakeTable("Playlist", "#", "Track Name")
 	for i, line := range player.Playlist.GetList(amount) {
-		output.addRow(strconv.Itoa(i), line)
+		output.AddRow(strconv.Itoa(i), line)
 	}
-	output.addRow("---")
-	output.addRow(strconv.Itoa(player.Playlist.Size()-current), " Track(s) queued.")
+	output.AddRow("---")
+	output.AddRow(strconv.Itoa(player.Playlist.Size()-current), " Track(s) queued.")
 	helper.MsgDispatch(player.GetClient(), isPrivate, sender, output.String())
 }
 
 func find(player *playback.Player, sender string, isPrivate bool, arg string) {
 	results := search.SearchALL(arg)
-	output := makeTable("Search Results")
+	output := messages.MakeTable("Search Results")
 	for i, v := range results {
-		output.addRow(v)
+		output.AddRow(v)
 		if i == config.MaxLines { // TODO, Send extra results into 'more' buffer
 			break
 		}
@@ -145,14 +148,14 @@ func rand(player *playback.Player, sender string, isPrivate bool, arg string) {
 	plistOrigSize := player.Playlist.Size()
 	hadNext := player.Playlist.HasNext()
 
-	output := makeTable("Randomly Added")
+	output := messages.MakeTable("Randomly Added")
 	idList := search.GetRandomTrackIDs(value)
 	for _, v := range idList {
 		human := player.Playlist.QueueID(v)
 		if human != "" {
-			output.addRow("Added: <b>" + human + "</b>")
+			output.AddRow("Added: <b>" + human + "</b>")
 		} else {
-			output.addRow("Error: <b>" + "failed to add ID#" + strconv.Itoa(v) + "</b>")
+			output.AddRow("Error: <b>" + "failed to add ID#" + strconv.Itoa(v) + "</b>")
 		}
 	}
 	helper.MsgDispatch(player.GetClient(), isPrivate, sender, output.String())

--- a/commands/messages.go
+++ b/commands/messages.go
@@ -1,45 +1,104 @@
 package commands
 
 import (
+	"bytes"
+	"encoding/base64"
 	"fmt"
+	"github.com/iotku/mumzic/playback"
+	"github.com/nfnt/resize"
+	"image"
+	_ "image/jpeg"
+	"image/png"
+	"log"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
 type messageTable struct {
-    table *strings.Builder
-    cols int
+	table *strings.Builder
+	cols  int
 }
 
-// makeTable generates an html table with the first parameter as a header on top of the table
+// makeTable generates a html table with the first parameter as a header on top of the table
 // and subsequents as column headers for the table
 func makeTable(header string, columns ...string) messageTable {
-    var b strings.Builder
-    fmt.Fprintf(&b, "<h2 style=\"margin-top:16px; margin-bottom:2px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><b><u><span style=\"font-size:x-large\">%s</span></u></b></h2>", header)
-    fmt.Fprintf(&b, "<table align=\"left\" border=\"0\" style=\"margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;\" cellspacing=\"2\" cellpadding=\"0\"><thead>")
-    if len(columns) != 0 {
-        fmt.Fprintf(&b, "<tr>")
-    }
-    for _, v := range columns {
-        fmt.Fprintf(&b, "<th align=\"left\">%s</th>", v)
-    }
-    if len(columns) != 0 {
-        fmt.Fprintf(&b, "</tr>")
-    }
-    fmt.Fprintf(&b, "</thead><tbody>")
-    return messageTable{&b, len(columns)}
+	var b strings.Builder
+	fmt.Fprintf(&b, "<h2 style=\"margin-top:16px; margin-bottom:2px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><b><u><span style=\"font-size:x-large\">%s</span></u></b></h2>", header)
+	fmt.Fprintf(&b, "<table align=\"left\" border=\"0\" style=\"margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px;\" cellspacing=\"2\" cellpadding=\"0\"><thead>")
+	if len(columns) != 0 {
+		fmt.Fprintf(&b, "<tr>")
+	}
+	for _, v := range columns {
+		fmt.Fprintf(&b, "<th align=\"left\">%s</th>", v)
+	}
+	if len(columns) != 0 {
+		fmt.Fprintf(&b, "</tr>")
+	}
+	fmt.Fprintf(&b, "</thead><tbody>")
+	return messageTable{&b, len(columns)}
 }
 
 // addRow adds cells to a messageTable
 func (msgTbl messageTable) addRow(cells ...string) {
-    fmt.Fprintf(msgTbl.table, "<tr>")
-    for _,v := range cells {
-        fmt.Fprintf(msgTbl.table, "<td><p>%s</p></td>", v)
-    }
-    fmt.Fprintf(msgTbl.table, "</tr>")
+	fmt.Fprintf(msgTbl.table, "<tr>")
+	for _, v := range cells {
+		fmt.Fprintf(msgTbl.table, "<td><p>%s</p></td>", v)
+	}
+	fmt.Fprintf(msgTbl.table, "</tr>")
 }
 
 // String escapes the tbody and table elements of a messageTable and then returns a string of the messageTable
 func (msgTbl messageTable) String() string {
-    fmt.Fprintf(msgTbl.table, "</tbody></table>")
-    return msgTbl.table.String()
+	fmt.Fprintf(msgTbl.table, "</tbody></table>")
+	return msgTbl.table.String()
+}
+
+func FindCoverArtPath(player *playback.Player) string {
+	basedir := filepath.Dir(player.Playlist.GetCurrentPath())
+	// Todo, robust matching
+	if _, err := os.Stat(basedir + "/cover.jpg"); err == nil {
+		return basedir + "cover.jpg"
+	}
+	if _, err := os.Stat(basedir + "/cover.png"); err == nil {
+		return basedir + "cover.png"
+	}
+	return ""
+}
+
+// generateCoverArtImage creates a base64 encoded html <img>
+// TODO: Check for filesize limits for mumble servers
+func GenerateCoverArtImg(filepath string) string {
+	img, err := decodeImage(filepath)
+	if err != nil {
+		log.Println("Failed to decode img: ", filepath, " ", err)
+		return ""
+	}
+	resizedImg := resize.Resize(200, 200, img, resize.Lanczos3)
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, resizedImg); err != nil {
+		log.Println("Error encoding png for base64: ", filepath, " ", err)
+		return ""
+	}
+
+	encodedStr := base64.StdEncoding.EncodeToString(buf.Bytes())
+	return "<img src=\"data:img/png;base64, " + encodedStr + "\" />"
+}
+
+func decodeImage(filepath string) (image.Image, error) {
+	f, err := os.Open(filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	img, _, err := image.Decode(f)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := f.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	return img, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,7 @@ func LoadConfig(hostname string) {
 	}
 }
 
+// SaveConfig writes the current configuraiton to the configuration sqlite database
 func SaveConfig() {
 	fmt.Println("Writing configuration to disk")
 	db := openDB(configPath)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.10
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	layeh.com/gumble v0.0.0-20200818122324-146f9205029b
 )
 

--- a/go.sum
+++ b/go.sum
@@ -5,5 +5,7 @@ github.com/iotku/gumble v0.0.1 h1:b1mhMtKX+qDL7eCP4PzN0ZIOysCGcmZcYmvsWgFO2oM=
 github.com/iotku/gumble v0.0.1/go.mod h1:tWPVA9ZAfImNwabjcd9uDE+Mtz0Hfs7a7G3vxrnrwyc=
 github.com/mattn/go-sqlite3 v1.14.10 h1:MLn+5bFRlWMGoSRmJour3CL1w/qL96mvipqpwQW/Sfk=
 github.com/mattn/go-sqlite3 v1.14.10/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 layeh.com/gopus v0.0.0-20161224163843-0ebf989153aa h1:WNU4LYsgD2UHxgKgB36mL6iMAMOvr127alafSlgBbiA=
 layeh.com/gopus v0.0.0-20161224163843-0ebf989153aa/go.mod h1:AOef7vHz0+v4sWwJnr0jSyHiX/1NgsMoaxl+rEPz/I0=

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func main() {
 				config.LastChannel = e.Channel.Name
 				fmt.Println("Last Channel Changed to", config.LastChannel)
 			}
+			channelPlayer.TargetUsers()
 		},
 		Disconnect: func(e *gumble.DisconnectEvent) {
 			fmt.Println("Disconnecting: ", e.Type)


### PR DESCRIPTION
A very rudimentary album art implementation that looks for cover.jpg or cover.png in the file path of the media file.

Currently we are unable to get the correct `imagemessagelength` restriction from mumble servers so we're limited to the much smaller `textmessagelength`