### PR TITLE
Wrap checkErrPanic in config.go in anonymous function with defer to avoid panic

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -69,7 +69,9 @@ func (config *Config) Save() {
 		log.Fatal(err)
 	}
 	stmt := prepareUpdate(tx)
-	defer checkErrPanic(stmt.Close())
+	defer func() {
+		checkErrPanic(stmt.Close())
+	}()
 	// There must be a better way to do this, but I'm tired and this will do for now.
 	_, err = stmt.Exec(config.Volume, config.Channel, config.Prefix, config.Hostname)
 	checkErrPanic(err)


### PR DESCRIPTION
So `defer checkErrPanic()` evaluates immediately and by wrapping it in anon func we ensure that we close it only when surrounding function ends/returns.

## Some logs

I was just testing Mumble server and when I closed it while mumzic was still running, the mumzic panicked.

```
2026/01/13 16:08:49 Disconnecting:  1
2026/01/13 16:08:49 Writing configuration to disk
panic: sql: statement is closed

goroutine 15 [running]:
github.com/iotku/mumzic/config.checkErrPanic(...)
        /mumzic/config/config.go:154
github.com/iotku/mumzic/config.(*Config).Save(0xc000214a00)
        /mumzic/config/config.go:75 +0x271
main.main.func4(0x6?)
        /mumzic/main.go:57 +0xf8
layeh.com/gumble/gumbleutil.Listener.OnDisconnect(...)
        /go/pkg/mod/github.com/iotku/gumble@v0.0.1/gumbleutil/listener.go:35
layeh.com/gumble/gumble.(*Listeners).onDisconnect(0xc00002ebd0?, 0xc0001e20d8)
        /go/pkg/mod/github.com/iotku/gumble@v0.0.1/gumble/listeners.go:59 +0xad
layeh.com/gumble/gumble.(*Client).readRoutine(0xc0001e2000)
        /go/pkg/mod/github.com/iotku/gumble@v0.0.1/gumble/client.go:247 +0xec
created by layeh.com/gumble/gumble.DialWithDialer in goroutine 1
        /go/pkg/mod/github.com/iotku/gumble@v0.0.1/gumble/client.go:116 +0x2ae
```
