### PR TITLE
Check that SongDB exists before closing the connection to it

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -2,8 +2,9 @@ package database
 
 import (
 	"database/sql"
-	"github.com/iotku/mumzic/config"
 	"os"
+
+	"github.com/iotku/mumzic/config"
 )
 
 var SongDB *sql.DB
@@ -37,5 +38,7 @@ func checkErrPanic(err error) {
 }
 
 func Close() {
-	checkErrPanic(SongDB.Close())
+	if SongDB != nil {
+		checkErrPanic(SongDB.Close())
+	}
 }


### PR DESCRIPTION
This PR removes quite a specific panic that is only possible if:

- The one does not have `media.db` 
- Mumzic closed the connection and tries to save to the disk

Essentially it just tries to close connection that does not exists and it just dies. Though maybe instead of check for existance of `SongDB` it should instead just create an empty one? Your call!